### PR TITLE
Close #29: Category selection

### DIFF
--- a/classes/DB.php
+++ b/classes/DB.php
@@ -361,6 +361,24 @@ SQL;
     }
 
     /**
+     * @return array
+     */
+    public static function findAllCategories()
+    {
+        $db = self::getConnection();
+        $statement = $db->prepare('SELECT DISTINCT categories FROM articles');
+        $result = $statement->execute();
+        $categories = array();
+        while (($record = $result->fetchArray(SQLITE3_ASSOC)) !== false) {
+            if ($record['categories'] === ',,') continue;
+            $categories = array_merge($categories, explode(',', trim($record['categories'], ',')));
+        }
+        $categories = array_unique($categories);
+        sort($categories);
+        return $categories;
+    }
+
+     /**
      * @param int $id
      * @return stdClass
      */

--- a/classes/MainAdminController.php
+++ b/classes/MainAdminController.php
@@ -157,7 +157,9 @@ class MainAdminController extends AbstractController
                 assert(false);
         }
         $this->useCalendar();
-        $bjs .= '<script type="text/javascript" src="' . $pth['folder']['plugins']
+        $bjs .= '<script type="text/javascript">REALBLOG.categories = '
+            . json_encode(DB::findAllCategories()) . ';</script>'
+            . '<script type="text/javascript" src="' . $pth['folder']['plugins']
             . 'realblog/realblog.js"></script>';
         $view = new View('article-form');
         $view->article = $article;

--- a/languages/de.php
+++ b/languages/de.php
@@ -46,6 +46,7 @@ $plugin_tx['realblog']['id_label']="ID";
 $plugin_tx['realblog']['label_rss']="RSS-Feed";
 $plugin_tx['realblog']['label_status']="Status";
 $plugin_tx['realblog']['label_categories']="Kategorien";
+$plugin_tx['realblog']['label_category_add']="Kategorie hinzufügen:";
 $plugin_tx['realblog']['links_visible_text']="Aktuelle Artikel im Blog:";
 $plugin_tx['realblog']['menu_main']="Artikel";
 $plugin_tx['realblog']['message_comments_0']="Dieser Artikel wurde nicht kommentiert.";

--- a/languages/en.php
+++ b/languages/en.php
@@ -46,6 +46,7 @@ $plugin_tx['realblog']['id_label']="ID";
 $plugin_tx['realblog']['label_rss']="RSS feed";
 $plugin_tx['realblog']['label_status']="Status";
 $plugin_tx['realblog']['label_categories']="Categories";
+$plugin_tx['realblog']['label_category_add']="Add Category:";
 $plugin_tx['realblog']['links_visible_text']="Newest entries in Blog:";
 $plugin_tx['realblog']['menu_main']="Articles";
 $plugin_tx['realblog']['message_comments_0']="There are no comments on this article.";

--- a/realblog.js
+++ b/realblog.js
@@ -48,3 +48,34 @@ REALBLOG.initDatePickers = function () {
 }
 
 REALBLOG.initDatePickers();
+
+(function () {
+    var select, i, option;
+
+    if (REALBLOG.categories) {
+        select = document.getElementById("realblog_category_select");
+        if (select) {
+            for (i = 0; i < REALBLOG.categories.length; i++) {
+                option = document.createElement("option");
+                option.text = option.value = REALBLOG.categories[i];
+                select.add(option);
+            }
+            select.onchange = function (event) {
+                var target, input, category;
+    
+                event = event || window.event;
+                target = event.target || event.srcElement;
+                input = document.getElementById("realblog_categories");
+                if (input && target.selectedIndex) {
+                    category = target[target.selectedIndex].value;
+                    if (input.value) {
+                        input.value += "," + category;
+                    } else {
+                        input.value = category;
+                    }
+                }
+                target.selectedIndex = 0;
+            };
+        }
+    }
+}());

--- a/views/article-form.php
+++ b/views/article-form.php
@@ -69,6 +69,9 @@
         <p>
             <label for="realblog_categories" class="realblog_label"><?=$this->text('label_categories')?></label>
             <input type="text" id="realblog_categories" name="realblog_categories" value="<?=$this->categories?>" size="50">
+            <select id="realblog_category_select">
+                <option><?=$this->text('label_category_add')?></option>
+            </select>
         </p>
         <p>
             <label for="realblog_title" class="realblog_label"><?=$this->text('title_label')?></label>


### PR DESCRIPTION
We make it easier for the admin to add existing categories to an
article by offering a select element where all categories are pickable.
Picking a category will add it to the categories input without any
checking whether the category is already there. It is still the admin's
responsibility to properly set the categories input, and to delete
undesired categories manually.